### PR TITLE
fix: replace deprecated set-output with $GITHUB_OUTPUT in test.yml (#…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: |
+          echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
Fixes talentprotocol/contracts#108

Replaced deprecated ::set-output syntax with $GITHUB_OUTPUT 
in test.yml GitHub Actions workflow.
